### PR TITLE
Operator import explanation

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -90,6 +90,6 @@
 * [Recipes](/recipes/README.md)
    * [Smart Counter](/recipes/smartcounter.md)
 * [Concepts](/concepts/README.md)
-   * [Using Operators in Public Libraries](/concepts/operator-imports.md)
+   * [Understanding Operator Imports](/concepts/operator-imports.md)
 
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -90,5 +90,6 @@
 * [Recipes](/recipes/README.md)
    * [Smart Counter](/recipes/smartcounter.md)
 * [Concepts](/concepts/README.md)
+   * [Using Operators in Public Libraries](/concepts/operator-imports.md)
 
 

--- a/concepts/README.md
+++ b/concepts/README.md
@@ -3,4 +3,4 @@
 Short explanations of common RxJS scenarios and use-cases.
 
 ### Contents
-* [Using Operators In Public Libraries](operator-imports.md)
+* [Understanding Operator Imports](operator-imports.md)

--- a/concepts/README.md
+++ b/concepts/README.md
@@ -1,3 +1,6 @@
 # Concepts
 
-*Coming soon...*
+Short explanations of common RxJS scenarios and use-cases.
+
+### Contents
+* [Using Operators In Public Libraries](operator-imports.md)

--- a/concepts/operator-imports.md
+++ b/concepts/operator-imports.md
@@ -1,0 +1,138 @@
+# Using Operators in Public Libraries
+
+A problem you may have run into in the past when consuming or creating a public library that depends on RxJS is handling operator inclusion. The most predominant way to include operators in your project is to import them like below:
+
+```ts
+import 'rxjs/add/operator/take';
+```
+
+This adds the imported operator to the `Observable` prototype for use throughout your project:
+
+[(Source)](https://github.com/ReactiveX/rxjs/blob/master/src/add/operator/take.ts)
+
+```ts
+import { Observable } from '../../Observable';
+import { take } from '../../operator/take';
+
+Observable.prototype.take = take;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    take: typeof take;
+  }
+}
+```
+
+This is method is generally *OK* for private projects and modules, the issue arises when you are using these imports in say, a public [npm](https://www.npmjs.com/) package or library to be consumed throughout your organization.
+
+### A Quick Example
+
+To see where a problem can spring up, let's imagine **Person A** is creating a public Angular component library. In this library you need a few operators so you add the typical imports:
+
+*my-public-library.ts*
+```ts
+import 'rxjs/add/operator/take';
+import 'rxjs/add/operator/concatMap';
+import 'rxjs/add/operator/switchMap';
+```
+
+**Person B** comes along with `file > new project` and includes your library. They now have access to these operators even though they did not personally import them. *Probably not a huge deal but it can be confusing.* You use the library and operators, life goes on...
+
+A month later **Person A** decides to update their library. They no longer need `switchMap` or `concatMap` so they remove the imports:
+
+*my-public-library.ts*
+```ts
+import 'rxjs/add/operator/take';
+```
+
+**Person B** upgrades the dependency, builds their project, which now fails. They never included `switchMap` or `concatMap` themselves, it was **just working** based on the inclusion of a 3rd party dependency. If you were not aware this could be an issue it may take a while to track down.
+
+### The Solution
+
+Instead of importing operators like:
+
+```ts
+import 'rxjs/add/operator/take';
+```
+
+We can instead import them like:
+
+```ts
+import { take } from 'rxjs/operator/take';
+```
+
+This keeps them off the `Observable` prototype and let's us call them directly:
+
+```ts
+import { take } from 'rxjs/operator/take';
+import { of } from 'rxjs/observable/of';
+
+take.call(
+  of(1,2,3), 
+  2
+);
+```
+
+This is already getting **ugly** however, imagine we have a longer chain:
+
+```ts
+import { take } from 'rxjs/operator/take';
+import { map } from 'rxjs/operator/map';
+import { of } from 'rxjs/observable/of';
+
+map.call(
+  take.call(
+    of(1,2,3), 
+    2
+  ),
+  val => val + 2
+);
+```
+
+Pretty soon we have a block of code that is near impossible to understand. How can we get the best of both worlds?
+
+### Chaining Helpers
+
+RxJS (and more, discussed below) now come with a [`pipe`](https://github.com/ReactiveX/rxjs/blob/755df9bf908108974e38aaff79887279f2cde008/src/Observable.ts#L305-L329) helper that alleviates the pain of not having operators on the prototype. We can take the ugly block of code from above:
+
+```ts
+import { take } from 'rxjs/operator/take';
+import { map } from 'rxjs/operator/map';
+import { of } from 'rxjs/observable/of';
+
+map.call(
+  take.call(
+    of(1,2,3), 
+    2
+  ),
+  val => val + 2
+);
+```
+
+And transform it into:
+
+```ts
+import { take } from 'rxjs/operator/take';
+import { map } from 'rxjs/operator/map';
+import { of } from 'rxjs/observable/of';
+
+of(1,2,3)
+  .pipe(
+    take(2),
+    map(val => val + 2)
+  );
+```
+
+Much easier to read, right? If you are developing in Angular and using the [`@angular/cdk`](https://www.npmjs.com/package/@angular/cdk) you can utilize the `RxChain` helper method for a similar feel:
+
+```ts
+import { of } from 'rxjs/observable/of';
+import { RxChain, map, debounceTime } from '@angular/cdk/rxjs';
+
+RxChain
+  .from(of(1,2,3))
+  .call(map, val => val + 2)
+  .call(debounceTime, 1000)
+```
+
+Whichever syntax you prefer, both approaches make it easy for you to keep a clean operator chain while maintaining a clean prototype for other projects!

--- a/concepts/operator-imports.md
+++ b/concepts/operator-imports.md
@@ -1,4 +1,4 @@
-# Using Operators in Public Libraries
+# Understanding Operator Imports
 
 A problem you may have run into in the past when consuming or creating a public library that depends on RxJS is handling operator inclusion. The most predominant way to include operators in your project is to import them like below:
 
@@ -23,29 +23,29 @@ declare module '../../Observable' {
 }
 ```
 
-This is method is generally *OK* for private projects and modules, the issue arises when you are using these imports in say, a public [npm](https://www.npmjs.com/) package or library to be consumed throughout your organization.
+This is method is generally *OK* for private projects and modules, the issue arises when you are using these imports in say, an [npm](https://www.npmjs.com/) package or library to be consumed throughout your organization.
 
 ### A Quick Example
 
 To see where a problem can spring up, let's imagine **Person A** is creating a public Angular component library. In this library you need a few operators so you add the typical imports:
 
-*my-public-library.ts*
+*some-public-library.ts*
 ```ts
 import 'rxjs/add/operator/take';
 import 'rxjs/add/operator/concatMap';
 import 'rxjs/add/operator/switchMap';
 ```
 
-**Person B** comes along with `file > new project` and includes your library. They now have access to these operators even though they did not personally import them. *Probably not a huge deal but it can be confusing.* You use the library and operators, life goes on...
+**Person B** comes along and includes your library. They now have access to these operators even though they did not personally import them. *Probably not a huge deal but it can be confusing.* You use the library and operators, life goes on...
 
 A month later **Person A** decides to update their library. They no longer need `switchMap` or `concatMap` so they remove the imports:
 
-*my-public-library.ts*
+*some-public-library.ts*
 ```ts
 import 'rxjs/add/operator/take';
 ```
 
-**Person B** upgrades the dependency, builds their project, which now fails. They never included `switchMap` or `concatMap` themselves, it was **just working** based on the inclusion of a 3rd party dependency. If you were not aware this could be an issue it may take a while to track down.
+**Person B** upgrades the dependency, builds their project, which now fails. They never included `switchMap` or `concatMap` themselves, it was **just working** based on the inclusion of a 3rd party dependency. If you were not aware this could be an issue that can take a bit to track down.
 
 ### The Solution
 
@@ -73,7 +73,7 @@ take.call(
 );
 ```
 
-This is already getting **ugly** however, imagine we have a longer chain:
+This quickly gets **ugly** however, imagine we have a longer chain:
 
 ```ts
 import { take } from 'rxjs/operator/take';
@@ -91,9 +91,9 @@ map.call(
 
 Pretty soon we have a block of code that is near impossible to understand. How can we get the best of both worlds?
 
-### Chaining Helpers
+### RxJS Helpers
 
-RxJS (and more, discussed below) now come with a [`pipe`](https://github.com/ReactiveX/rxjs/blob/755df9bf908108974e38aaff79887279f2cde008/src/Observable.ts#L305-L329) helper that alleviates the pain of not having operators on the prototype. We can take the ugly block of code from above:
+RxJS now comes with a [`pipe`](https://github.com/ReactiveX/rxjs/blob/755df9bf908108974e38aaff79887279f2cde008/src/Observable.ts#L305-L329) helper that alleviates the pain of not having operators on the prototype. We can take the ugly block of code from above:
 
 ```ts
 import { take } from 'rxjs/operator/take';
@@ -123,7 +123,7 @@ of(1,2,3)
   );
 ```
 
-Much easier to read, right? If you are developing in Angular and using the [`@angular/cdk`](https://www.npmjs.com/package/@angular/cdk) you can utilize the `RxChain` helper method for a similar feel:
+Much easier to read, right? If you are developing in Angular and using the [`@angular/cdk`](https://www.npmjs.com/package/@angular/cdk) you can utilize the `RxChain` function and helper methods right now for a similar feel:
 
 ```ts
 import { of } from 'rxjs/observable/of';
@@ -135,4 +135,4 @@ RxChain
   .call(debounceTime, 1000)
 ```
 
-Whichever syntax you prefer, both approaches make it easy for you to keep a clean operator chain while maintaining a clean prototype for other projects!
+Whichever approach you prefer, both make it easy for you to keep a readable operator chain while maintaining a clean prototype for other projects!


### PR DESCRIPTION
Explanation for importing and using operators when creating public libraries. Waiting on future RxJS release to publish.