### PR TITLE
Removed link to cache from summary

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,7 +35,6 @@
         * [retry](/operators/error_handling/retry.md)
         * [retryWhen](/operators/error_handling/retrywhen.md)
     * [Multicasting](/operators/multicasting/README.md)
-        * [cache](/operators/multicasting/cache.md)
         * [publish](/operators/multicasting/publish.md)
         * [multicast](/operators/multicasting/multicast.md)
         * [share](/operators/multicasting/share.md)


### PR DESCRIPTION
Link to cache in the multicasting section doesn't point anywhere. 