### PR TITLE
Update summary and utility operators

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -64,6 +64,7 @@
         * [bufferWhen](/operators/transformation/bufferwhen.md)
         * [concatMap](/operators/transformation/concatmap.md)
         * [concatMapTo](/operators/transformation/concatmapto.md)
+        * [exhaustMap](/operators/transformation/exhaustmap.md)
         * [expand](/operators/transformation/expand.md)
         * [groupBy](/operators/transformation/groupby.md)
         * [map](/operators/transformation/map.md)

--- a/operators/utility/README.md
+++ b/operators/utility/README.md
@@ -9,8 +9,6 @@ provide helpful utilities in your observable toolkit.
 * [delayWhen](delaywhen.md)
 * [dematerialize](dematerialize.md)
 * [let](let.md)
-* [materialize](materialize.md)
-* [observeOn](observeon.md)
 * [toPromise](topromise.md)
 
 :star: - *commonly used*


### PR DESCRIPTION
Just noticed a couple of things when reading through the docs, this PR fixes the following:

- Missing `exhaustMap` link to the summary
- A couple of utility operator (`materialize` + `observeOn`) links that don't exist