### PR TITLE
Add link to Reactive.how

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ jump start your learning experience!
 #### Tools
 * [Rx Marbles - Interactive diagrams of Rx Observables](http://rxmarbles.com/) - André Staltz
 * [Rx Visualizer - Animated playground for Rx Observables](https://rxviz.com) - Misha Moroshko
+* [Reactive.how - Animated cards to learn Reactive Programming](http://reactive.how) - Cédric Soulas
 
 *Interested in RxJS 4? Check out [Denis Stoyanov's](https://github.com/xgrommx) excellent [eBook](https://xgrommx.github.io/rx-book/)!*
 


### PR DESCRIPTION
Add link to [reactive.how](http://reactive.how) in the Tools section of the README.

Series of animated visualization of Rx operators, in the form of cards. For example:

<a href="http://reactive.how"><img width="584" alt="capture d ecran 2017-11-03 a 10 53 45" src="https://user-images.githubusercontent.com/802010/32368233-62efa63c-c085-11e7-8dca-8f5224d7faa4.png"></a>
