### PR TITLE
Fixed withLatestFrom example source

### DIFF
--- a/operators/combination/withlatestfrom.md
+++ b/operators/combination/withlatestfrom.md
@@ -27,11 +27,10 @@ const source = interval(5000);
 //emit every 1s
 const secondSource = interval(1000);
 const example = source.pipe(
-  withLatestFrom(secondSource).pipe(
-    map(([first, second]) => {
-      return `First Source (5s): ${first} Second Source (1s): ${second}`;
-    })
-  )
+  withLatestFrom(secondSource),
+  map(([first, second]) => {
+    return `First Source (5s): ${first} Second Source (1s): ${second}`;
+  })
 );
 /*
   "First Source (5s): 0 Second Source (1s): 4"
@@ -58,7 +57,7 @@ const secondSource = interval(1000);
 //withLatestFrom slower than source
 const example = secondSource.pipe(
     //both sources must emit at least 1 value (5s) before emitting
-    withLatestFrom(source)
+    withLatestFrom(source),
     map(([first, second]) => {
       return `Source (1s): ${first} Latest From (5s): ${second}`;
     })


### PR DESCRIPTION
In the first example a second .pipe() was used against the withLatestFrom() result which doesn't compile. I don't think the nested pipe is needed here. In the second example the comma after withLatestFrom() was missing.