### PR TITLE
Update pairwise.md

### DIFF
--- a/operators/combination/pairwise.md
+++ b/operators/combination/pairwise.md
@@ -15,11 +15,10 @@
 import { pairwise, take } from 'rxjs/operators';
 import { interval } from 'rxjs/observable/interval';
 
-var interval = interval(1000);
 
 //Returns: [0,1], [1,2], [2,3], [3,4], [4,5]
-interval.pipe(
-    pairwise()
+interval(1000).pipe(
+    pairwise(),
     take(5)
   )
   .subscribe(console.log);


### PR DESCRIPTION
fixed errors.

declaring a variable with interval conflicts with import,
missing comma in pipe operator arguments.