### PR TITLE
Fix link to ReactiveX/rxjs do.ts

### DIFF
--- a/operators/utility/do.md
+++ b/operators/utility/do.md
@@ -25,7 +25,7 @@ const subscribe = example.subscribe(val => console.log(val));
 
 ### Additional Resources
 
-* [do](https://github.com/ReactiveX/rxjs/blob/master/src/internal/operators/do.ts)
+* [do](https://github.com/ReactiveX/rxjs/blob/master/src/internal/patching/operator/do.ts)
   :newspaper: - Official docs
 * [Logging a stream with do](https://egghead.io/lessons/rxjs-logging-a-stream-with-do?course=step-by-step-async-javascript-with-rxjs)
   :video_camera: :dollar: - John Linquist


### PR DESCRIPTION
This PR fixes the link to `ReactiveX/rxjs do.ts`.