### PR TITLE
Update catch.md

### DIFF
--- a/operators/error_handling/catch.md
+++ b/operators/error_handling/catch.md
@@ -42,7 +42,7 @@ const subscribe = example.subscribe(val => console.log(val));
 ```js
 import { timer } from 'rxjs/observable/timer';
 import { fromPromise } from 'rxjs/observable/timer';
-import { of } from 'rxjs/observable/timer';
+import { of } from 'rxjs/observable/of';
 import { mergeMap, catchError } from 'rxjs/operators';
 
 //create promise that immediately rejects


### PR DESCRIPTION
Typo in catchError.
changed: import { of } from 'rxjs/observable/timer';
to: import { of } from 'rxjs/observable/of';
