### PR TITLE
Add commonly used star for delay operator

### DIFF
--- a/operators/README.md
+++ b/operators/README.md
@@ -88,7 +88,7 @@ _[Prefer a complete list in alphabetical order?](complete.md)_
   * [windowWhen](transformation/windowwhen.md)
 * [Utility](utility/README.md)
   * [do / tap](utility/do.md) :star:
-  * [delay](utility/delay.md)
+  * [delay](utility/delay.md) :star:
   * [delayWhen](utility/delaywhen.md)
   * [finalize / finally](finalize.md)
   * [let](utility/let.md)


### PR DESCRIPTION
The [Operators](https://www.learnrxjs.io/operators/) page does not show the star for the `delay` operator, while the [Utility](https://www.learnrxjs.io/operators/utility/) does. Made the two pages consistent.