### PR TITLE
feat(github-buttons): fix js error for github buttons config

### DIFF
--- a/book.json
+++ b/book.json
@@ -24,9 +24,20 @@
       "token": "UA-54001708-2"
     },
     "github-buttons": {
-      "repo": "btroncone/learn-rxjs",
-      "types": ["star", "watch"],
-      "size": "large"
+      "buttons": [
+        {
+          "user": "btroncone",
+          "repo": "learn-rxjs",
+          "type": "star",
+          "size": "small"
+        },
+        {
+          "user": "btroncone",
+          "repo": "learn-rxjs",
+          "type": "watch",
+          "size": "small"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
adapted book.json to the newer gitbook github buttons plugin api.

The newer api require settings the buttons in an array "buttons" property:

```json
{
  "plugins": [
    "github-buttons"
  ],
  "pluginsConfig": {
    "github-buttons": {
      "buttons": [{
        "user": "azu",
        "repo": "JavaScript-Plugin-Architecture",
        "type": "star",
        "size": "large"
      }, {
        "user": "azu",
        "type": "follow",
        "width": "230",
        "count": false
      }]
    }
  }
}
```

https://github.com/azu/gitbook-plugin-github-buttons/blob/4458c2386564ddf4fac878bdd1bcf261f8ff1fe2/src/plugin.js#L88

Currently, I get js error on "buttons" undefined. After that, the search stops from working.