### PR TITLE
Remove unused operator from Operators Used

### DIFF
--- a/recipes/type-ahead.md
+++ b/recipes/type-ahead.md
@@ -59,4 +59,3 @@ Get continents
 - [of](../operators/creation/of.md)
 - [switchMap](../operators/transformation/switchmap.md)
 - [tap](../operators/utility/do.md)
-- [throttleTime](../operators/filtering/throttletime.md)


### PR DESCRIPTION
Remove `throttleTime` from operator used when it's not