### PR TITLE
Disconnect Type Head from throttleTime

### DIFF
--- a/operators/filtering/throttletime.md
+++ b/operators/filtering/throttletime.md
@@ -58,7 +58,6 @@ const subscribe = example.subscribe(val => console.log(val));
 ### Related Recipes
 
 - [Horizontal Scroll Indicator](../../recipes/horizontal-scroll-indicator.md)
-- [Type Ahead](../../recipes/type-ahead.md)
 
 ### Additional Resources
 


### PR DESCRIPTION
Type Head is written as it's in the related recipes of `throttleTime` while it's not