### PR TITLE
Fix forkJoin example on StackBlitz.

### DIFF
--- a/operators/combination/forkjoin.md
+++ b/operators/combination/forkjoin.md
@@ -42,7 +42,7 @@ correct choice. In these cases you may better off with an operator like
 ##### Example 1: Observables completing after different durations
 
 (
-[StackBlitz](https://stackblitz.com/edit/typescript-bqxg9x?file=index.ts&devtoolsheight=100)
+[StackBlitz](https://stackblitz.com/edit/typescript-mzbcrw?file=index.ts&devtoolsheight=100)
 | [jsBin](http://jsbin.com/remiduhimu/1/edit?js,console) |
 [jsFiddle](https://jsfiddle.net/btroncone/5fj77920/81/) )
 


### PR DESCRIPTION
I think the current example is incorrect because it doesn't use forkJoin operator.