### PR TITLE
Mark Marble Testing video as not free

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ experience!
 - [What is RxJS?](https://egghead.io/lessons/rxjs-what-is-rxjs) - Ben Lesh
 - [Creating Observable from Scratch](https://egghead.io/lessons/rxjs-creating-observable-from-scratch) -
   Ben Lesh
-- [Introduction to RxJS Marble Testing](https://egghead.io/lessons/rxjs-introduction-to-rxjs-marble-testing) -
-  Brian Troncone
+- [Introduction to RxJS Marble Testing](https://egghead.io/lessons/rxjs-introduction-to-rxjs-marble-testing)
+  :dollar: - Brian Troncone
 - [Introduction to Reactive Programming](https://egghead.io/courses/introduction-to-reactive-programming)
   :dollar: - André Staltz
 - [Reactive Programming using Observables](https://www.youtube.com/watch?v=HT7JiiqnYYc&feature=youtu.be) -


### PR DESCRIPTION
Checking the links section I found that https://egghead.io/lessons/rxjs-introduction-to-rxjs-marble-testing isn't free anymore.
This PR marks this video with 💵 sign similar to "Introduction to Reactive Programming" above.