### PR TITLE
Update Subject page to fix broken example link

### DIFF
--- a/subjects/subject.md
+++ b/subjects/subject.md
@@ -27,7 +27,7 @@ sub.next(3); // OUTPUT => 3,3 (logged from both subscribers)
 
 ### Related Recipes
 
-- [Lockscreen](../../recipes/lockscreen.md)
+- [Lockscreen](../recipes/lockscreen.md)
 
 ### Additional Resources
 


### PR DESCRIPTION
Link to the 'lockscreen' example is broken, you get a 404 error when trying to reach it from the Subject page.