### PR TITLE
Coherent variable for constant numeric value

### DIFF
--- a/concepts/rxjs-primer.md
+++ b/concepts/rxjs-primer.md
@@ -457,10 +457,10 @@ There are also operators that share a similar goal but offer flexibility in
 their triggers. For instance, for unsubscribing from an observable after a
 specific condition is met, we could use:
 
-1. [`take`](../operators/filtering/take.md) when we know we only ever want `x`
+1. [`take`](../operators/filtering/take.md) when we know we only ever want `n`
    values.
 2. [`takeLast`](../operators/filtering/takelast.md) when you just want the last
-   n values.
+   `n` values.
 3. [`takeWhile`](../operators/filtering/takewhile.md) when we have a predicate
    expression to supply.
 4. [`takeUntil`](../operators/filtering/takeuntil.md) when we only want the


### PR DESCRIPTION
`take` explanation used '`x`' for explaining taking `n` values then just afterward `takeLast` used 'n'.

I choose a middle ground with `n` because n is often associated with Int, and the use of ``(backtick) allow for a more readable sentence in my opinion.

Other options would have been:
- `x` for both sentences
- x for both sentences
- n for both sentences
- completely another way to convey the meaning, so long as it is consistant.