### PR TITLE
docs(do): "save indicator" broken link on gitbook

### DIFF
--- a/operators/utility/do.md
+++ b/operators/utility/do.md
@@ -83,7 +83,7 @@ const example = source
 - [Memory Game](../../recipes/memory-game.md)
 - [Mine Sweeper Game](../../recipes/mine-sweeper-game.md)
 - [Platform Jumper Game](../../recipes/platform-jumper-game.md)
-- [Save Indicator]('../../recipes/save-indicator.md)
+- [Save Indicator](../../recipes/save-indicator.md)
 - [Space Invaders Game](/recipes/space-invaders-game.md)
 - [Stop Watch](../../recipes/stop-watch.md)
 - [Swipe To Refresh](/recipes/swipe-to-refresh.md)


### PR DESCRIPTION
the `'` at the start of the link was breaking the rendering on GitBook (https://www.learnrxjs.io/learn-rxjs/operators/utility/do)

Looks like the `'` is in the recipe list of other operators pages as well, but I'm just doing a quick edit through the web interface. Can't stop for this right now.