### PR TITLE
Fix broken link

### DIFF
--- a/operators/creation/fromevent.md
+++ b/operators/creation/fromevent.md
@@ -45,7 +45,7 @@ const subscribe = example.subscribe(val => console.log(val));
 - [Mine Sweeper Game](../../recipes/mine-sweeper-game.md)
 - [Platform Jumper Game](../../recipes/platform-jumper-game.md)
 - [Progress Bar](../../recipes/progressbar.md)
-- [Save Indicator]('../../recipes/save-indicator.md)
+- [Save Indicator](../../recipes/save-indicator.md)
 - [Smart Counter](../../recipes/smartcounter.md)
 - [Space Invaders Game](../../recipes/space-invaders-game.md)
 - [Stop Watch](../../recipes/stop-watch.md)


### PR DESCRIPTION
It's a minor typo and you can't see it in the page rendered on GitHub, but GitBook seems to not understand a link with unclosed quote.

<img width="385" alt="Screenshot 2020-12-05 at 21 58 56" src="https://user-images.githubusercontent.com/107447/101261198-724fc180-3746-11eb-9367-2a492a906bc6.png">
