### PR TITLE
Clarify forkjoin error behavior

### DIFF
--- a/operators/combination/forkjoin.md
+++ b/operators/combination/forkjoin.md
@@ -25,9 +25,10 @@ similar to how you might use
 Be aware that if any of the inner observables supplied to `forkJoin` error you
 will lose the value of any other observables that would or have already
 completed if you do not [`catch`](../error_handling/catch.md) the
-[error correctly on the inner observable](#example-4-getting-successful-results-when-one-innner-observable-errors).
-If you are only concerned with all inner observables completing successfully you
-can [catch the error on the outside](#example-3-handling-errors-on-outside).
+[error correctly on the inner observable](#example-5-getting-successful-results-when-one-innner-observable-errors).
+Without catching on the inner observable an error will cause all observables to
+immediately be unsubscribed. If this is not an issue you
+can [catch the error on the outside](#example-4-handling-errors-on-outside).
 
 It's also worth noting that if you have an observable that emits more than one
 item, and you are concerned with the previous emissions `forkJoin` is not the


### PR DESCRIPTION
I read the learn rxjs documentation, then read the main documentation at:
https://rxjs.dev/api/index/function/forkJoin

which states:
"""
If any given observable errors at some point, forkJoin will error as well and immediately unsubscribe from the other observables.
"""

I felt that the learn-rxjs documentation conflicted with that statement.  Here is my suggestion on how to improve the learn-rxjs documentation to properly reflect wha the main documentation states.

I also fixed a couple example links that were in the same area.