### PR TITLE
fix(operators): fix broken image

### DIFF
--- a/operators/utility/topromise.md
+++ b/operators/utility/topromise.md
@@ -10,7 +10,7 @@
 
 ---
 
-<div class="ua-ad">[![Ultimate RxJS](https://drive.google.com/uc?export=view&id=1qq2-q-eVe-F_-d0eSvTyqaGRjpfLDdJz "Ultimate RxJS")](https://ultimatecourses.com/courses/rxjs?ref=4)</div>
+[![Ultimate RxJS](https://drive.google.com/uc?export=view&id=1qq2-q-eVe-F_-d0eSvTyqaGRjpfLDdJz 'Ultimate RxJS')](https://ultimatecourses.com/courses/rxjs?ref=4)
 
 ### Examples
 


### PR DESCRIPTION
Using `<div class="ua-ad"> ... </div>` causes the markdown image not to render properly.