### PR TITLE
fix(iif.md): update the link to the official docs

### DIFF
--- a/operators/conditional/iif.md
+++ b/operators/conditional/iif.md
@@ -84,7 +84,7 @@ interval(1000)
 
 ### Additional Resources
 
-- [iif](https://rxjs.dev/api/operators/iif) 📰 - Official docs
+- [iif](https://rxjs.dev/api/index/function/iif) 📰 - Official docs
 
 ---
 


### PR DESCRIPTION
The link to the official docs was outdated  and pointed to a 404 page on rxjs.dev.