### PR TITLE
fix(concat): update concat operator

### DIFF
--- a/operators/combination/concat.md
+++ b/operators/combination/concat.md
@@ -47,14 +47,14 @@ concat(
 
 ```js
 // RxJS v6+
-import { concat, empty } from 'rxjs';
+import { concat, EMPTY } from 'rxjs';
 import { delay, startWith } from 'rxjs/operators';
 
 // elems
 const userMessage = document.getElementById('message');
 // helper
 const delayedMessage = (message, delayedTime = 1000) => {
-  return empty().pipe(startWith(message), delay(delayedTime));
+  return EMPTY.pipe(startWith(message), delay(delayedTime));
 };
 
 concat(


### PR DESCRIPTION
Change empty() into EMPTY because it is deprecated. Will be removed in v8.